### PR TITLE
Better error when hitting a non-successful response code from Firebase

### DIFF
--- a/account.js
+++ b/account.js
@@ -143,7 +143,9 @@ FirebaseAccount.prototype.createDatabase = function(name) {
     if (err) {
       deferred.reject(err);
     } else if (response.statusCode !== 200) {
-      deferred.reject(new Error(response.body));
+      var error = new Error(response.body.error.message)
+      error.code = response.body.error.code
+      deferred.reject(error);
     } else if (body.error) {
       deferred.reject(new Error('Firebase error: ' + body.error));
     } else if (body.success === false) {

--- a/account.js
+++ b/account.js
@@ -143,7 +143,8 @@ FirebaseAccount.prototype.createDatabase = function(name) {
     if (err) {
       deferred.reject(err);
     } else if (response.statusCode !== 200) {
-      deferred.reject(new Error(response.statusCode));
+      console.log(response);
+      deferred.reject(new Error(response));
     } else if (body.error) {
       deferred.reject(new Error('Firebase error: ' + body.error));
     } else if (body.success === false) {

--- a/account.js
+++ b/account.js
@@ -143,8 +143,7 @@ FirebaseAccount.prototype.createDatabase = function(name) {
     if (err) {
       deferred.reject(err);
     } else if (response.statusCode !== 200) {
-      console.log(response);
-      deferred.reject(new Error(response));
+      deferred.reject(new Error(response.body));
     } else if (body.error) {
       deferred.reject(new Error('Firebase error: ' + body.error));
     } else if (body.success === false) {


### PR DESCRIPTION
Ran into the scenario where Firebase returned a 429 error, but that was all the info that ended up in the error message. The true error message has more details saying that we had reached our limit of number of databases, so let's expose that extra useful info.
